### PR TITLE
Fix: rendering when hightlighted is outside the displayed date range

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -601,6 +601,9 @@ export default class Gantt {
         ) {
             // Used as we must find the _end_ of session if view is not Day
             const { x: left, date } = this.computeGridHighlightDimensions(this.options.view_mode);
+            if (date < this.gantt_start || date > this.gantt_end) {
+                return;
+            }
             const top = this.options.header_height + this.options.padding / 2;
             const height = (this.options.bar_height + this.options.padding) * this.tasks.length;
             this.$current_highlight = this.create_el({
@@ -610,7 +613,6 @@ export default class Gantt {
                 classes: 'current-highlight',
                 append_to: this.$container,
             });
-            let $today = document.getElementById(date_utils.format(date).replaceAll(' ', '_'));
 
             $today.classList.add('current-date-highlight');
             $today.style.top = +$today.style.top.slice(0, -2) - 4 + 'px';


### PR DESCRIPTION
This PR fixes a bug that can be currently noticed in the demo page: when the current date is largely outside the displayed range, a part of the Gantt is not correctly drawn.