### PR TITLE
fix: $today is not defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -614,6 +614,7 @@ export default class Gantt {
                 append_to: this.$container,
             });
 
+            let $today = document.getElementById(date_utils.format(date).replaceAll(' ', '_'));
             $today.classList.add('current-date-highlight');
             $today.style.top = +$today.style.top.slice(0, -2) - 4 + 'px';
             $today.style.left = +$today.style.left.slice(0, -2) - 8 + 'px';


### PR DESCRIPTION
The 1.0.2 contains an error that was wrongly introduced by removing a line that defined a $today variable. This PR restores the definition of this variable.